### PR TITLE
Add support for _L _R Suffix on chiral bone names

### DIFF
--- a/Source/PMXImporter/PMXImporter.Build.cs
+++ b/Source/PMXImporter/PMXImporter.Build.cs
@@ -19,7 +19,8 @@ public class PMXImporter : ModuleRules
             "InterchangeFactoryNodes",
             "InterchangeCommonParser",
             "PhysicsCore",
-            "MeshDescription"
+            "MeshDescription",
+            "SkeletalMeshModifiers",
         });
 
         PrivateDependencyModuleNames.AddRange(new string[]
@@ -37,7 +38,8 @@ public class PMXImporter : ModuleRules
             "AnimationCore",
             "AssetRegistry",
             // For image resizing/utilities used by the translator when handling texture payloads
-            "ImageCore"
+            "ImageCore",
+            "SkeletalMeshModifiers",
         });
 
         PublicIncludePaths.AddRange(new string[]

--- a/Source/PMXImporter/PMXImporter.Build.cs
+++ b/Source/PMXImporter/PMXImporter.Build.cs
@@ -20,7 +20,6 @@ public class PMXImporter : ModuleRules
             "InterchangeCommonParser",
             "PhysicsCore",
             "MeshDescription",
-            "SkeletalMeshModifiers",
         });
 
         PrivateDependencyModuleNames.AddRange(new string[]
@@ -39,6 +38,7 @@ public class PMXImporter : ModuleRules
             "AssetRegistry",
             // For image resizing/utilities used by the translator when handling texture payloads
             "ImageCore",
+            // For renaming bones
             "SkeletalMeshModifiers",
         });
 

--- a/Source/PMXImporter/Private/PmxPipeline.cpp
+++ b/Source/PMXImporter/Private/PmxPipeline.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Jeonghyeon Ha. All Rights Reserved.
+﻿// Copyright (c) 2025 Jeonghyeon Ha. All Rights Reserved.
 
 #include "PmxPipeline.h"
 #include "LogPMXImporter.h"
@@ -216,7 +216,6 @@ void UPmxPipeline::StoreOptionsToSourceNode(UInterchangeBaseNodeContainer* BaseN
 	SourceNode->AddBooleanAttribute(PmxPipelineAttributeKeys::RenameLRBones, bRenameLRBones);
 	SourceNode->AddBooleanAttribute(PmxPipelineAttributeKeys::FixIKLinks, bFixIKLinks);
 	SourceNode->AddBooleanAttribute(PmxPipelineAttributeKeys::ApplyBoneFixedAxis, bApplyBoneFixedAxis);
-	SourceNode->AddBooleanAttribute(PmxPipelineAttributeKeys::UseUnderscore, bUseUnderscore);
 
 	// Physics options
 	SourceNode->AddBooleanAttribute(PmxPipelineAttributeKeys::ImportPhysics, bImportPhysics);
@@ -870,7 +869,6 @@ void UPmxPipeline::FilterPropertiesFromTranslatedData(UInterchangeBaseNodeContai
 		HideProperty(this, this, GET_MEMBER_NAME_CHECKED(UPmxPipeline, bRenameLRBones));
 		HideProperty(this, this, GET_MEMBER_NAME_CHECKED(UPmxPipeline, bFixIKLinks));
 		HideProperty(this, this, GET_MEMBER_NAME_CHECKED(UPmxPipeline, bApplyBoneFixedAxis));
-		HideProperty(this, this, GET_MEMBER_NAME_CHECKED(UPmxPipeline, bUseUnderscore));
 	}
 
 	// Hide physics sub-options if not importing physics

--- a/Source/PMXImporter/Private/PmxPipeline.cpp
+++ b/Source/PMXImporter/Private/PmxPipeline.cpp
@@ -24,6 +24,8 @@
 #include "Rendering/SkeletalMeshLODModel.h"
 #include "Rendering/SkeletalMeshModel.h"
 
+#include "SkeletonModifier.h"
+
 #include UE_INLINE_GENERATED_CPP_BY_NAME(PmxPipeline)
 
 // PMX option attribute keys
@@ -81,6 +83,83 @@ bool UPmxPipeline::CanExecuteOnAnyThread(EInterchangePipelineTask PipelineTask)
 		return false;
 	}
 	return true;
+}
+
+void UPmxPipeline::RenameLRBones(UInterchangeSkeletalMeshFactoryNode* SkeletalMeshFactoryNode) const
+{
+	if (!bRenameLRBones)
+	{
+		return;
+	}
+
+
+	// Get the reference to the created SkeletalMesh
+	FSoftObjectPath SkeletalMeshPath;
+	if (!SkeletalMeshFactoryNode->GetCustomReferenceObject(SkeletalMeshPath))
+	{
+		UE_LOG(LogPMXImporter, Warning, TEXT("UPmxPipeline: SkeletalMeshFactoryNode has no ReferenceObject"));
+		return;
+	}
+
+	USkeletalMesh* SkeletalMesh = Cast<USkeletalMesh>(SkeletalMeshPath.TryLoad());
+	if (!SkeletalMesh)
+	{
+		UE_LOG(LogPMXImporter, Warning, TEXT("UPmxPipeline: Failed to load SkeletalMesh from '%s'"), *SkeletalMeshPath.ToString());
+		return;
+	}
+
+	USkeleton* Skeleton = SkeletalMesh->GetSkeleton();
+
+	if (Skeleton)
+	{	
+		TArray<FName> RemovedBones;
+
+		// Get the reference skeleton
+		FReferenceSkeleton RefSkeleton = Skeleton->GetReferenceSkeleton();
+		
+		// Create the modifier
+		USkeletonModifier* SkeletonModifier = NewObject<USkeletonModifier>();
+		SkeletonModifier->SetSkeletalMesh(SkeletalMesh);
+		FReferenceSkeletonModifier RefSkeletonModifier(RefSkeleton, Skeleton);
+
+		const TArray<FMeshBoneInfo>& BoneInfoArray = RefSkeleton.GetRefBoneInfo();
+		// TArray<FName> AllBoneNames;
+		bool Changed = false;
+		for (const FMeshBoneInfo& BoneInfo : BoneInfoArray)
+		{
+			// AllBoneNames.Add(BoneInfo.Name);
+			// UE_LOG(LogPMXImporter, Warning, TEXT("BONE NAME: %s"), *BoneInfo.Name.ToString());
+			if (BoneInfo.Name.ToString().StartsWith(TEXT("左")))
+			{
+				// UE_LOG(LogPMXImporter, Warning, TEXT("L: %s , %s"), *BoneInfo.Name.ToString(), *(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));
+				// SkeletonModifier.Rename(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));
+				RemovedBones.Add(BoneInfo.Name);
+				SkeletonModifier->RenameBone(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));
+				
+				Changed = true;
+			}
+			else if (BoneInfo.Name.ToString().StartsWith(TEXT("右")))
+			{
+				RemovedBones.Add(BoneInfo.Name);
+				// UE_LOG(LogPMXImporter, Warning, TEXT("R: %s , %s"), *BoneInfo.Name.ToString(), *(BoneInfo.Name.ToString().RightChop(1) + TEXT("_R")));
+				// SkeletonModifier.Rename(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_R")));
+				SkeletonModifier->RenameBone(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_R")));
+				Changed = true;
+			}
+		}
+		if (Changed)
+		{
+			SkeletalMesh->MarkPackageDirty();
+			Skeleton->MarkPackageDirty();
+			bool bSuccess = SkeletonModifier->CommitSkeletonToSkeletalMesh();
+			UE_LOG(LogPMXImporter, Warning, TEXT("SAVED : %d"), bSuccess);
+		}
+		// Clean up bones from skeleton
+		for (int i = 0; i < RemovedBones.Num(); i++) 
+		{
+			RefSkeletonModifier.Remove(RemovedBones[i], false);
+		}
+	}
 }
 
 void UPmxPipeline::ExecutePipeline(UInterchangeBaseNodeContainer* BaseNodeContainer, const TArray<UInterchangeSourceData*>& SourceDatas, const FString& ContentBasePath)
@@ -714,6 +793,48 @@ void UPmxPipeline::ExecutePostImportPipeline(const UInterchangeBaseNodeContainer
 		{
 			UE_LOG(LogPMXImporter, Log, TEXT("UPmxPipeline: No PMX physics cache found for '%s'"), *MeshName);
 		}
+
+
+		if (bRenameLRBones)
+		{
+			bool Changed = false;
+			for (USkeletalBodySetup* BodySetup : PhysicsAsset->SkeletalBodySetups)
+			{
+				if (BodySetup->BoneName.ToString().StartsWith(TEXT("左")))
+				{
+					UE_LOG(LogPMXImporter, Log, TEXT("LEFT PHYSICS"));
+					BodySetup->BoneName = FName(BodySetup->BoneName.ToString().RightChop(1) + TEXT("_L"));
+					Changed = true;
+				}
+				else if (BodySetup->BoneName.ToString().StartsWith(TEXT("右")))
+				{
+					BodySetup->BoneName = FName(BodySetup->BoneName.ToString().RightChop(1) + TEXT("_R"));
+					Changed = true;
+				}
+			}
+			
+			if (Changed)
+			{
+				// Force the physics asset to re-initialize constraints/bodies
+				PhysicsAsset->UpdateBodySetupIndexMap();
+				PhysicsAsset->UpdateBoundsBodiesArray();
+			}
+			
+		}
+	}
+
+	// Change bone names at the end
+	{
+		const FString SkeletalMeshUid = TEXT("/PMX/SkeletalMesh");
+		UInterchangeSkeletalMeshFactoryNode* SkeletalMeshFactoryNode =
+			Cast<UInterchangeSkeletalMeshFactoryNode>(BaseNodeContainer->GetFactoryNode(SkeletalMeshUid));
+
+		if (!SkeletalMeshFactoryNode)
+		{
+			UE_LOG(LogPMXImporter, Warning, TEXT("UPmxPipeline: Could not find SkeletalMeshFactoryNode '%s'"), *SkeletalMeshUid);
+			return;
+		}
+		RenameLRBones(SkeletalMeshFactoryNode);
 	}
 }
 

--- a/Source/PMXImporter/Private/PmxPipeline.cpp
+++ b/Source/PMXImporter/Private/PmxPipeline.cpp
@@ -112,37 +112,22 @@ void UPmxPipeline::RenameLRBones(UInterchangeSkeletalMeshFactoryNode* SkeletalMe
 
 	if (Skeleton)
 	{	
-		TArray<FName> RemovedBones;
-
-		// Get the reference skeleton
-		FReferenceSkeleton RefSkeleton = Skeleton->GetReferenceSkeleton();
-		
 		// Create the modifier
 		USkeletonModifier* SkeletonModifier = NewObject<USkeletonModifier>();
 		SkeletonModifier->SetSkeletalMesh(SkeletalMesh);
-		FReferenceSkeletonModifier RefSkeletonModifier(RefSkeleton, Skeleton);
 
-		const TArray<FMeshBoneInfo>& BoneInfoArray = RefSkeleton.GetRefBoneInfo();
-		// TArray<FName> AllBoneNames;
+		const TArray<FMeshBoneInfo>& BoneInfoArray = SkeletalMesh->GetRefSkeleton().GetRefBoneInfo();
+		
 		bool Changed = false;
 		for (const FMeshBoneInfo& BoneInfo : BoneInfoArray)
 		{
-			// AllBoneNames.Add(BoneInfo.Name);
-			// UE_LOG(LogPMXImporter, Warning, TEXT("BONE NAME: %s"), *BoneInfo.Name.ToString());
 			if (BoneInfo.Name.ToString().StartsWith(TEXT("左")))
 			{
-				// UE_LOG(LogPMXImporter, Warning, TEXT("L: %s , %s"), *BoneInfo.Name.ToString(), *(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));
-				// SkeletonModifier.Rename(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));
-				RemovedBones.Add(BoneInfo.Name);
-				SkeletonModifier->RenameBone(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));
-				
+				SkeletonModifier->RenameBone(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_L")));	
 				Changed = true;
 			}
 			else if (BoneInfo.Name.ToString().StartsWith(TEXT("右")))
 			{
-				RemovedBones.Add(BoneInfo.Name);
-				// UE_LOG(LogPMXImporter, Warning, TEXT("R: %s , %s"), *BoneInfo.Name.ToString(), *(BoneInfo.Name.ToString().RightChop(1) + TEXT("_R")));
-				// SkeletonModifier.Rename(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_R")));
 				SkeletonModifier->RenameBone(BoneInfo.Name, FName(BoneInfo.Name.ToString().RightChop(1) + TEXT("_R")));
 				Changed = true;
 			}
@@ -152,12 +137,6 @@ void UPmxPipeline::RenameLRBones(UInterchangeSkeletalMeshFactoryNode* SkeletalMe
 			SkeletalMesh->MarkPackageDirty();
 			Skeleton->MarkPackageDirty();
 			bool bSuccess = SkeletonModifier->CommitSkeletonToSkeletalMesh();
-			UE_LOG(LogPMXImporter, Warning, TEXT("SAVED : %d"), bSuccess);
-		}
-		// Clean up bones from skeleton
-		for (int i = 0; i < RemovedBones.Num(); i++) 
-		{
-			RefSkeletonModifier.Remove(RemovedBones[i], false);
 		}
 	}
 }
@@ -801,7 +780,6 @@ void UPmxPipeline::ExecutePostImportPipeline(const UInterchangeBaseNodeContainer
 			{
 				if (BodySetup->BoneName.ToString().StartsWith(TEXT("左")))
 				{
-					UE_LOG(LogPMXImporter, Log, TEXT("LEFT PHYSICS"));
 					BodySetup->BoneName = FName(BodySetup->BoneName.ToString().RightChop(1) + TEXT("_L"));
 					Changed = true;
 				}
@@ -817,6 +795,7 @@ void UPmxPipeline::ExecutePostImportPipeline(const UInterchangeBaseNodeContainer
 				// Force the physics asset to re-initialize constraints/bodies
 				PhysicsAsset->UpdateBodySetupIndexMap();
 				PhysicsAsset->UpdateBoundsBodiesArray();
+				PhysicsAsset->MarkPackageDirty();
 			}
 			
 		}

--- a/Source/PMXImporter/Private/PmxTranslator.cpp
+++ b/Source/PMXImporter/Private/PmxTranslator.cpp
@@ -127,10 +127,6 @@ bool UPmxTranslator::Translate(UInterchangeBaseNodeContainer& BaseNodeContainer)
         {
             ImportOptions.bApplyBoneFixedAxis = bValue;
         }
-        if (SourceNode->GetBooleanAttribute(TEXT("PMX:UseUnderscore"), bValue))
-        {
-            ImportOptions.bUseUnderscore = bValue;
-        }
 
         // Physics options
         if (SourceNode->GetBooleanAttribute(TEXT("PMX:ImportPhysics"), bValue))

--- a/Source/PMXImporter/Public/PmxPipeline.h
+++ b/Source/PMXImporter/Public/PmxPipeline.h
@@ -5,6 +5,9 @@
 #include "CoreMinimal.h"
 #include "InterchangePipelineBase.h"
 #include "PmxTranslator.h"
+
+#include "InterchangeSkeletalMeshFactoryNode.h"
+
 #include "PmxPipeline.generated.h"
 
 class UInterchangeBaseNodeContainer;
@@ -297,6 +300,8 @@ private:
 
 	/** Build physics asset from PMX physics data */
 	void BuildPmxPhysicsAsset(UPhysicsAsset* PhysicsAsset, USkeletalMesh* SkeletalMesh, const FPmxPhysicsCache& PhysicsData) const;
+
+	void RenameLRBones(UInterchangeSkeletalMeshFactoryNode* SkeletalMeshFactoryNode) const;
 
 	/** Cached base node container for post-import access */
 	UPROPERTY(Transient)

--- a/Source/PMXImporter/Public/PmxPipeline.h
+++ b/Source/PMXImporter/Public/PmxPipeline.h
@@ -99,10 +99,6 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skeleton", meta = (EditCondition = "bImportArmature", ToolTip = "Apply bone fixed axis constraints"))
 	bool bApplyBoneFixedAxis = false;
 
-	/** Use underscore for bone name separator instead of dot. */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Skeleton", meta = (EditCondition = "bImportArmature && bRenameLRBones", ToolTip = "Use underscore for bone name separator instead of dot"))
-	bool bUseUnderscore = false;
-
 	// =============================================
 	// Physics Category (Basic Options)
 	// =============================================

--- a/Source/PMXImporter/Public/PmxTranslator.h
+++ b/Source/PMXImporter/Public/PmxTranslator.h
@@ -106,9 +106,6 @@ struct FPmxImportOptions
     UPROPERTY()
     bool bRenameLRBones = false;
 
-    UPROPERTY()
-    bool bUseUnderscore = false;
-
     // Physics options
     UPROPERTY()
     EPmxPhysicsType2Handling PhysicsType2Mode = EPmxPhysicsType2Handling::ConvertToKinematic;


### PR DESCRIPTION
This commit includes the implementation in the Pipeline to support renaming the kanji characters to _L and _R suffixes. More details are outlined here: https://github.com/HaJH/PmxImporter/issues/3

When enabled, it will also correctly update the PhysicsAsset as well to match the renamed bones.

Other notes:
- `bUseUnderscore` is deprecated. UE doesn't natively support `.` in bone names or filenames across most systems so any existing bone names with `.` will already be coalesced into `_` by UE when importing.
- `bRenameLRBones` is currently enabled by default to match Blender's PMX import defaults.